### PR TITLE
#8 - Fix bugs with Windows socket implementations

### DIFF
--- a/demos/client_server/client_demo.cpp
+++ b/demos/client_server/client_demo.cpp
@@ -1,13 +1,17 @@
 #include "junkworks/udp_socket.hpp"
 
+#include "junkworks/basic_udp.h"
 #include <iostream>
 
 int main(int argc, char ** argv)
 {
    if (argc < 2)
    {
+      std::cout << "need port number as first argument\n";
       return 0;
    }
+
+   initialize_sockets();
 
    junkworks::UdpSocket socket(atoi(argv[1]));
 

--- a/demos/client_server/client_demo.cpp
+++ b/demos/client_server/client_demo.cpp
@@ -5,15 +5,24 @@
 
 int main(int argc, char ** argv)
 {
-   if (argc < 2)
+   if (argc < 6)
    {
-      std::cout << "need port number as first argument\n";
-      return 0;
+      std::cout << "server_ip0 server_ip1 server_ip2 server_ip3 client_port\n";
+      return 1;
    }
+
+   junkworks::ipv4add server_ip(
+      std::atoi(argv[1]),
+      std::atoi(argv[2]),
+      std::atoi(argv[3]),
+      std::atoi(argv[4])
+   );
+
+   const unsigned int bind_port = std::atoi(argv[5]);
 
    initialize_sockets();
 
-   junkworks::UdpSocket socket(atoi(argv[1]));
+   junkworks::UdpSocket socket(bind_port);
 
    if (!socket.bound())
    {
@@ -22,7 +31,7 @@ int main(int argc, char ** argv)
    }
 
    socket.try_send(
-      junkworks::ipv4add(127, 0, 0, 1), 8123, "stuff", sizeof("stuff")
+      server_ip, 8123, "stuff", sizeof("stuff")
    );
 
    return 0;

--- a/demos/client_server/server_demo.cpp
+++ b/demos/client_server/server_demo.cpp
@@ -1,6 +1,8 @@
 #include "junkworks/udp_socket.hpp"
 
+#include <chrono>
 #include <iostream>
+#include <thread>
 
 int main(int argc, char ** argv)
 {
@@ -25,6 +27,7 @@ int main(int argc, char ** argv)
       if (socket.try_receive(6, packet_data) > 0)
       {
          std::cout << "packet: " << packet_data << "\n";
+         std::this_thread::sleep_for(std::chrono::milliseconds(10));
       }
    }
 

--- a/demos/client_server/server_demo.cpp
+++ b/demos/client_server/server_demo.cpp
@@ -6,6 +6,7 @@ int main(int argc, char ** argv)
 {
    if (argc < 2)
    {
+      std::cout << "need port number as first argument\n";
       return 0;
    }
 

--- a/junkworks/CMakeLists.txt
+++ b/junkworks/CMakeLists.txt
@@ -23,10 +23,17 @@ set(
    junkworks
 )
 
-set(
-   junkwork_libs
-)
-
+if (WIN32)
+   set(
+      junkwork_libs
+      wsock32
+      ws2_32
+   )
+else()
+   set(
+      junkwork_libs
+   )
+endif()
 make_library(
    "${target}" "${junkwork_sources}" "${junkwork_headers}" "${junkwork_libs}" ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/junkworks/include/junkworks/udp_socket.hpp
+++ b/junkworks/include/junkworks/udp_socket.hpp
@@ -45,8 +45,6 @@ namespace junkworks
       private:
          bool bind_to(const unsigned int bind_port);
 
-         bool initialize_sockets(void);
-
          void shutdown_sockets(void);
 
          int socket_handle_;

--- a/junkworks/include/junkworks/udp_socket.hpp
+++ b/junkworks/include/junkworks/udp_socket.hpp
@@ -11,9 +11,9 @@ namespace junkworks
    class UdpSocket
    {
       public:
-         static bool sockets_initialized;
+         static bool os_sockets_initialized;
 
-         static bool socket_initialization_successful;
+         static bool os_socket_initialization_successful;
 
          UdpSocket(void) = delete;
 

--- a/junkworks/include/junkworks/udp_socket.hpp
+++ b/junkworks/include/junkworks/udp_socket.hpp
@@ -11,6 +11,8 @@ namespace junkworks
    class UdpSocket
    {
       public:
+         static bool sockets_initialized;
+
          UdpSocket(void) = delete;
 
          UdpSocket(const unsigned int bind_port);

--- a/junkworks/include/junkworks/udp_socket.hpp
+++ b/junkworks/include/junkworks/udp_socket.hpp
@@ -13,6 +13,8 @@ namespace junkworks
       public:
          static bool sockets_initialized;
 
+         static bool socket_initialization_successful;
+
          UdpSocket(void) = delete;
 
          UdpSocket(const unsigned int bind_port);

--- a/junkworks/src/basic_udp.c
+++ b/junkworks/src/basic_udp.c
@@ -1,5 +1,6 @@
 #include "junkworks/basic_udp.h"
 
+#include <stdint.h>
 #include <stdio.h>
 
 int initialize_sockets(void)
@@ -71,15 +72,15 @@ int bind_socket(const int handle, const unsigned int port)
       printf("Failed to set port as non-blocking\n");
       return 0;
    }
-#elif
+#elif PLATFORM == PLATFORM_WINDOWS
    DWORD non_blocking = 1;
    if (
-      isoctlsocket(
+      ioctlsocket(
          handle, FIONBIO, &non_blocking
       ) != 0
    )
    {
-      std::cout << "Failed to set port as non-blocking\n";
+      printf("Failed to set port as non-blocking\n");
       return 0;
    }
 #endif

--- a/junkworks/src/client.cpp
+++ b/junkworks/src/client.cpp
@@ -78,6 +78,9 @@ namespace junkworks
                got_response = true;
                std::cout << "Connection accepted! UID: " << uid_ << "\n";
             }
+            {
+               std::cout << "Rogue packet\n";
+            }
          }
          else
          {

--- a/junkworks/src/client.cpp
+++ b/junkworks/src/client.cpp
@@ -47,7 +47,7 @@ namespace junkworks
       bool got_response = false;
       for (auto & packet : packets_)
       {
-         const uint8_t packet_type = packet[0];
+         const char packet_type = packet[0];
          if (packet_type == 1)
          {
             if (
@@ -78,6 +78,10 @@ namespace junkworks
                got_response = true;
                std::cout << "Connection accepted! UID: " << uid_ << "\n";
             }
+         }
+         else
+         {
+            std::cout << "Unhandled packet type\n";
          }
       }
 

--- a/junkworks/src/client.cpp
+++ b/junkworks/src/client.cpp
@@ -78,9 +78,6 @@ namespace junkworks
                got_response = true;
                std::cout << "Connection accepted! UID: " << uid_ << "\n";
             }
-            {
-               std::cout << "Rogue packet\n";
-            }
          }
          else
          {

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -11,9 +11,6 @@ namespace junkworks
    bool UdpSocket::socket_initialization_successful = false;
 
    UdpSocket::UdpSocket(const unsigned int bind_port)
-      // : socket_handle_(socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP))
-      // , bound_(bind_to(bind_port))
-      // , bind_port_(bound_ ? bind_port : 0)
    {
       bound_ = false;
 

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -50,6 +50,11 @@ namespace junkworks
       const unsigned int data_len
    ) const
    {
+      if (!os_socket_initialization_successful)
+      {
+         return false;
+      }
+
       sockaddr_in send_address;
       send_address.sin_family = AF_INET;
       send_address.sin_addr.s_addr = dest_ip.internet_address();
@@ -79,6 +84,11 @@ namespace junkworks
       char * data
    ) const
    {
+      if (!os_socket_initialization_successful)
+      {
+         return 0;
+      }
+
       sockaddr_in from_address;
       int from_address_size = 0;
 
@@ -99,6 +109,11 @@ namespace junkworks
       std::vector<raw_payload_t<128> > & payloads
    ) const
    {
+      if (!os_socket_initialization_successful)
+      {
+         return;
+      }
+
       sockaddr_in from_address;
       int from_address_size = sizeof(from_address);
 

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -1,5 +1,6 @@
 #include "junkworks/udp_socket.hpp"
 
+#include "junkworks/basic_udp.h"
 #include "junkworks/network_common.h"
 
 #include <iostream>

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -7,22 +7,23 @@
 
 namespace junkworks
 {
-   bool UdpSocket::sockets_initialized = false;
+   bool UdpSocket::os_sockets_initialized = false;
 
-   bool UdpSocket::socket_initialization_successful = false;
+   bool UdpSocket::os_socket_initialization_successful = false;
 
    UdpSocket::UdpSocket(const unsigned int bind_port)
    {
       bound_ = false;
 
-      if (!sockets_initialized)
+      if (!os_sockets_initialized)
       {
-         socket_initialization_successful = initialize_sockets();
-         sockets_initialized = true;
+         os_socket_initialization_successful = initialize_sockets();
+         os_sockets_initialized = true;
       }
 
-      if (!socket_initialization_successful)
+      if (!os_socket_initialization_successful)
       {
+         std::cout << "Couldn't initialize OS sockets\n";
          socket_handle_ = -1;
          bind_port_ = 0;
          return;

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -91,7 +91,7 @@ namespace junkworks
 
       sockaddr_in from_address;
 
-#if PLATFORM == PLATFORM_MAC || PLATFORM == PLATFORM_LINUX
+#if PLATFORM == PLATFORM_MAC || PLATFORM == PLATFORM_UNIX
       unsigned int from_address_size = 0;
 #elif PLATFORM == PLATFORM_WINDOWS
       int from_address_size = 0;
@@ -121,7 +121,7 @@ namespace junkworks
 
       sockaddr_in from_address;
 
-#if PLATFORM == PLATFORM_MAC || PLATFORM == PLATFORM_LINUX
+#if PLATFORM == PLATFORM_MAC || PLATFORM == PLATFORM_UNIX
       unsigned int from_address_size = 0;
 #elif PLATFORM == PLATFORM_WINDOWS
       int from_address_size = 0;

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -59,7 +59,7 @@ namespace junkworks
    ) const
    {
       sockaddr_in from_address;
-      unsigned int from_address_size = 0;
+      int from_address_size = 0;
 
       // any packet larger than 'max_packet_size' will be dropped
       int num_bytes_received = recvfrom(
@@ -79,7 +79,7 @@ namespace junkworks
    ) const
    {
       sockaddr_in from_address;
-      unsigned int from_address_size = sizeof(from_address);
+      int from_address_size = sizeof(from_address);
 
       raw_payload_t<128> temp_payload;
       temp_payload.size = 1;
@@ -113,6 +113,7 @@ namespace junkworks
    {
       if (socket_handle_ < 0)
       {
+         std::cout << "bad socket handle: " << socket_handle_ << "\n";
          return false;
       }
 
@@ -142,7 +143,7 @@ namespace junkworks
       }
 
       // set socket as non-blocking
-   #if PLATFORM == PLATFORM_MAC || \
+#if PLATFORM == PLATFORM_MAC || \
       PLATFORM == PLATFORM_UNIX
       int non_blocking = 1;
       if (
@@ -154,18 +155,18 @@ namespace junkworks
          std::cout << "Failed to set port as non-blocking\n";
          return false;
       }
-   #elif
+#elif PLATFORM == PLATFORM_WINDOWS
       DWORD non_blocking = 1;
       if (
-         isoctlsocket(
-            handle, FIONBIO, &non_blocking
+         ioctlsocket(
+            socket_handle_, FIONBIO, &non_blocking
          ) != 0
       )
       {
          std::cout << "Failed to set port as non-blocking\n";
          return false;
       }
-   #endif
+#endif
 
       return true;
    }

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -92,9 +92,9 @@ namespace junkworks
       sockaddr_in from_address;
 
 #if PLATFORM == PLATFORM_MAC || PLATFORM == PLATFORM_UNIX
-      unsigned int from_address_size = 0;
+      unsigned int from_address_size = sizeof(sockaddr_in);
 #elif PLATFORM == PLATFORM_WINDOWS
-      int from_address_size = 0;
+      int from_address_size = sizeof(sockaddr_in);
 #endif
 
       // any packet larger than 'max_packet_size' will be dropped
@@ -122,9 +122,9 @@ namespace junkworks
       sockaddr_in from_address;
 
 #if PLATFORM == PLATFORM_MAC || PLATFORM == PLATFORM_UNIX
-      unsigned int from_address_size = 0;
+      unsigned int from_address_size = sizeof(sockaddr_in);
 #elif PLATFORM == PLATFORM_WINDOWS
-      int from_address_size = 0;
+      int from_address_size = sizeof(sockaddr_in);
 #endif
 
       raw_payload_t<128> temp_payload;

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -35,11 +35,11 @@ namespace junkworks
 
    UdpSocket::~UdpSocket(void)
    {
-   #if PLATFORM == PLATFORM_MAC || PLATFORM == PLATFORM_UNIX
+#if PLATFORM == PLATFORM_MAC || PLATFORM == PLATFORM_UNIX
       close(socket_handle_);
-   #elif PLATFORM == PLATFORM_WINDOWS
+#elif PLATFORM == PLATFORM_WINDOWS
       closesocket(socket_handle_);
-   #endif
+#endif
    }
 
    bool UdpSocket::try_send(

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -97,7 +97,9 @@ namespace junkworks
       int from_address_size = sizeof(sockaddr_in);
 #endif
 
-      // any packet larger than 'max_packet_size' will be dropped
+      // Any packet larger than 'max_packet_size' will be dropped.
+      // On Windows 'from_address_size' has to be non-zero to get IP address
+      // information from incoming packets.
       int num_bytes_received = recvfrom(
          socket_handle_,
          data,
@@ -132,6 +134,8 @@ namespace junkworks
 
       do
       {
+         // On Windows 'from_address_size' has to be non-zero to get IP
+         // address information from incoming packets.
          temp_payload.size = recvfrom(
             socket_handle_,
             temp_payload.data,

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -6,12 +6,34 @@
 
 namespace junkworks
 {
+   bool UdpSocket::sockets_initialized = false;
+
+   bool UdpSocket::socket_initialization_successful = false;
 
    UdpSocket::UdpSocket(const unsigned int bind_port)
-      : socket_handle_(socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP))
-      , bound_(bind_to(bind_port))
-      , bind_port_(bound_ ? bind_port : 0)
-   { }
+      // : socket_handle_(socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP))
+      // , bound_(bind_to(bind_port))
+      // , bind_port_(bound_ ? bind_port : 0)
+   {
+      bound_ = false;
+
+      if (!sockets_initialized)
+      {
+         socket_initialization_successful = initialize_sockets();
+         sockets_initialized = true;
+      }
+
+      if (!socket_initialization_successful)
+      {
+         socket_handle_ = -1;
+         bind_port_ = 0;
+         return;
+      }
+
+      socket_handle_ = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+      bound_ = bind_to(bind_port);
+      bind_port_ = bound_ ? bind_port : 0;
+   }
 
    UdpSocket::~UdpSocket(void)
    {

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -127,8 +127,6 @@ namespace junkworks
       int from_address_size = 0;
 #endif
 
-      // int from_address_size = sizeof(from_address);
-
       raw_payload_t<128> temp_payload;
       temp_payload.size = 1;
 

--- a/junkworks/src/udp_socket.cpp
+++ b/junkworks/src/udp_socket.cpp
@@ -90,7 +90,12 @@ namespace junkworks
       }
 
       sockaddr_in from_address;
+
+#if PLATFORM == PLATFORM_MAC || PLATFORM == PLATFORM_LINUX
+      unsigned int from_address_size = 0;
+#elif PLATFORM == PLATFORM_WINDOWS
       int from_address_size = 0;
+#endif
 
       // any packet larger than 'max_packet_size' will be dropped
       int num_bytes_received = recvfrom(
@@ -115,7 +120,14 @@ namespace junkworks
       }
 
       sockaddr_in from_address;
-      int from_address_size = sizeof(from_address);
+
+#if PLATFORM == PLATFORM_MAC || PLATFORM == PLATFORM_LINUX
+      unsigned int from_address_size = 0;
+#elif PLATFORM == PLATFORM_WINDOWS
+      int from_address_size = 0;
+#endif
+
+      // int from_address_size = sizeof(from_address);
 
       raw_payload_t<128> temp_payload;
       temp_payload.size = 1;


### PR DESCRIPTION
## Features

- Fixes unforgivable bugs in the Windows implementation of the socket code (missing `#define`s, misspelled API calls, incorrect types
- Updates the `UdpSocket` class to initialize the Windows OS sockets before attempting to bind to a socket
- Wraps the logic around initializing the OS's sockets inside a static boolean in the `UdpSocket` class
- Makes the origina client demo take in an IP address and port for the server from the command line

Closes #8 

